### PR TITLE
hacky hint fix

### DIFF
--- a/logic/logic.py
+++ b/logic/logic.py
@@ -327,12 +327,7 @@ class Logic:
             if it not in EXTENDED_ITEM:
                 continue
             bit = EXTENDED_ITEM[it]
-            if self.areas.requirements[bit].is_impossible() or bit not in pure_usefuls:
-                self.requirements[bit] &= banned_bit_inv
-            else:
-                raise ValueError(
-                    f"Cannot ban potentially inlined away requirement {it}"
-                )
+            self.requirements[bit] &= banned_bit_inv
 
         if optim:
             self.free_simplify(self.requirements, self.frees)

--- a/logic/randomize.py
+++ b/logic/randomize.py
@@ -106,11 +106,6 @@ class Rando:
 
         logic = Logic(areas, logic_settings, self.placement)
 
-        for loc in self.options["excluded-locations"]:
-            logic.requirements[EXTENDED_ITEM[self.norm(loc)]] &= DNFInventory(
-                BANNED_BIT
-            )
-
         self.rando_algo = FillAlgorithm(logic, self.rng, self.randosettings)
 
         self.randomised = False
@@ -245,6 +240,7 @@ class Rando:
         }
 
         self.banned: List[EIN] = []
+        self.banned.extend(map(self.norm, self.options["excluded-locations"]))
 
         if self.options["empty-unrequired-dungeons"]:
             self.banned.extend(


### PR DESCRIPTION
Makes hints work correctly for the co-op race. Hacky, not ready for main use since inlined requirements get weird if theyre not banned.